### PR TITLE
Enable usage of env variables for configuration

### DIFF
--- a/crates/hdlfs/src/lib.rs
+++ b/crates/hdlfs/src/lib.rs
@@ -45,7 +45,7 @@ impl ObjectStoreFactory for HdlfsFactory {
     ) -> DeltaResult<(ObjectStoreRef, Path)> {
         let config = config::SAPHdlfsConfigHelper::try_new(options.as_hdlfs_options())?.build()?;
 
-        let mut builder = SAPHdlfsBuilder::new()
+        let mut builder = SAPHdlfsBuilder::from_env()
             .with_url(url.to_string())
             .with_retry(retry.clone());
         for (key, value) in config.iter() {


### PR DESCRIPTION
This fix allows using env variables, such as HDLFS_STORAGE_PRIVATE_KEY and HDLFS_STORAGE_CERTIFICATE, for configuration.
